### PR TITLE
Do not enable prometheus endpoint when not configured on notification service

### DIFF
--- a/src/NotificationService/Program.cs
+++ b/src/NotificationService/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Dapr;
 using NotificationService;
 using NotificationService.Configuration;
@@ -62,9 +62,11 @@ app.MapHealthChecks("/healthz/readiness");
 logger.LogInformation(" - HealthProbe (readiness) activated");
 app.MapHealthChecks("/healthz/liveness");
 logger.LogInformation(" - HealthProbe (liveness) activated");
-
-app.UseOpenTelemetryPrometheusScrapingEndpoint();
-logger.LogInformation(" - Prometheus Scraping activated");
+if (cfg.ExposePrometheusMetrics)
+{
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
+    logger.LogInformation(" - Prometheus Scraping activated");
+}
 logger.LogInformation("All middlewares activated");
 
 app.Run();


### PR DESCRIPTION
When starting in docker-compose without Prometheus enabled, the notification service does not add the Prometheus services to the DI, but it tries to add the scraping endpoint, which requires these services. So the service crashes.

This change only enables the endpoint when it's configured. Code is the same as in the other services.