### PR TITLE
Fix typo in terraform file

### DIFF
--- a/iac/dapr/dapr.tf
+++ b/iac/dapr/dapr.tf
@@ -8,7 +8,7 @@ resource "helm_release" "dapr" {
   create_namespace = true
 }
 
-resource "kubernetes_manifest" "darp_configuration" {
+resource "kubernetes_manifest" "dapr_configuration" {
   manifest = {
     "apiVersion" = "dapr.io/v1alpha1"
     "kind"       = "Configuration"


### PR DESCRIPTION
Found a probable typo in a terraform file (`darp` -> `dapr`).

No other reference to the wrong string found, but not totally sure if this can be simply fixed without having a side-effect on stuff already published via TF.