### PR TITLE
Add missing auth config to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,9 @@ services:
     environment:
       DAPR_GRPC_PORT: 10001
       ProductsService__ZipkinEndpoint: http://zipkin:9411/api/v2/spans
+      ProductsService__IdentityServer__Authority: http://localhost:5009
+      ProductsService__IdentityServer__RequireHttpsMetadata: false
+      ProductsService__IdentityServer__MetadataAddress: http://authn:5000/.well-known/openid-configuration
     networks:
       - cloud-native
     depends_on:


### PR DESCRIPTION
When running in docker-compose, the order monitor client could not request the orders from the monitor endpoint, as the request from the products service was not correctly authenticated and returned a 401.

This PR adds the AuthN configuration to the products service in docker-compose so that the provided token is correctly accepted.