### PR TITLE
Update dapr deployment in cluster using Terraform

### DIFF
--- a/.github/workflows/dapr-cd.yml
+++ b/.github/workflows/dapr-cd.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   TERRAFORM_VERSION: 1.3.1
   KUBELOGIN_VERSION: v0.0.20
+  DAPR_VERSION: 1.10.5
 jobs:
   infra:
     name: "Deploy dapr to k8s"
@@ -57,6 +58,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.TERRAFORM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_SUBSCRIPTION_ID }}
+          TF_VAR_dapr_version: ${{ env.DAPR_VERSION }}
         working-directory: ./iac/dapr
       - name: Validate Terraform Project
         run: terraform validate -no-color
@@ -65,7 +67,17 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.TERRAFORM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_SUBSCRIPTION_ID }}
+          TF_VAR_dapr_version: ${{ env.DAPR_VERSION }}
         working-directory: ./iac/dapr
+      - name: Upgrade Dapr CRDs
+        run: |
+          kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v$DAPR_VERSION/charts/dapr/crds/components.yaml
+          kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v$DAPR_VERSION/charts/dapr/crds/configuration.yaml
+          kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v$DAPR_VERSION/charts/dapr/crds/subscription.yaml
+          kubectl apply -f https://raw.githubusercontent.com/dapr/dapr/v$DAPR_VERSION/charts/dapr/crds/resiliency.yaml
+        env:
+          DAPR_VERSION: ${{ env.DAPR_VERSION }}
+
       - name: Terraform Apply
         run: terraform apply -no-color -auto-approve
         env:
@@ -73,4 +85,5 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.TERRAFORM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.TERRAFORM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_SUBSCRIPTION_ID }}
+          TF_VAR_dapr_version: ${{ env.DAPR_VERSION }}
         working-directory: ./iac/dapr

--- a/iac/dapr/dapr.tf
+++ b/iac/dapr/dapr.tf
@@ -5,6 +5,7 @@ resource "helm_release" "dapr" {
   chart            = "dapr"
   timeout          = 600
   namespace        = "dapr-system"
+  version          = var.dapr_version
   create_namespace = true
 }
 

--- a/iac/dapr/variables.tf
+++ b/iac/dapr/variables.tf
@@ -3,6 +3,10 @@ variable "dapr_config_sample_rate" {
   default = 1
 }
 
+variable "dapr_version" {
+  type    = string
+  default = "1.10.5"
+}
 variable "dapr_api_auth_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
So far, terraform did not update the dapr control plane. With this PR, Terraform will update DAPR to the version specified in the corresponding GH action.

CAUTION ❗ The GitHub action is upgrading the CRDs because upgrading CRDs is not possible with Helm